### PR TITLE
SharedLink API

### DIFF
--- a/src/qdropbox.cpp
+++ b/src/qdropbox.cpp
@@ -262,6 +262,13 @@ void QDropbox::requestFinished(int nr, QNetworkReply *rply)
 		case QDROPBOX_REQ_BACCINF:
 			parseBlockingAccountInfo(response);
 			break;
+        case QDROPBOX_REQ_SHRDLNK:
+            parseSharedLink(response);
+            break;
+
+        case QDROPBOX_REQ_BSHRDLN:
+            parseBlockingSharedLink(response);
+            break;
         default:
             errorState  = QDropbox::ResponseToUnknownRequest;
             errorText   = "Received a response to an unknown request";
@@ -589,6 +596,29 @@ void QDropbox::parseAccountInfo(QString response)
     return;
 }
 
+void QDropbox::parseSharedLink(QString response)
+{
+#ifdef QTDROPBOX_DEBUG
+    qDebug() << "== shared link ==" << response << "== shared link end ==";
+#endif
+
+    //QDropboxJson json;
+    //json.parseString(response);
+    _tempJson.parseString(response);
+    if(!_tempJson.isValid())
+    {
+        errorState = QDropbox::APIError;
+        errorText  = "Dropbox API did not send correct answer for file/directory shared link.";
+#ifdef QTDROPBOX_DEBUG
+        qDebug() << "error: " << errorText << endl;
+#endif
+        emit errorOccured(errorState);
+        stopEventLoop();
+        return;
+    }
+    emit sharedLinkReceived(response);
+}
+
 void QDropbox::parseMetadata(QString response)
 {
 #ifdef QTDROPBOX_DEBUG
@@ -876,6 +906,52 @@ QDropboxFileInfo QDropbox::requestMetadataAndWait(QString file)
 	return fi;
 }
 
+void QDropbox::requestSharedLink(QString file, bool blocking)
+{
+    QUrl url;
+    url.setUrl(apiurl.toString());
+    url.addQueryItem("oauth_consumer_key",_appKey);
+    url.addQueryItem("oauth_nonce", nonce);
+    url.addQueryItem("oauth_signature_method", signatureMethodString());
+    url.addQueryItem("oauth_timestamp", QString::number(timestamp));
+    url.addQueryItem("oauth_token", oauthToken);
+    url.addQueryItem("oauth_version", _version);
+    url.setPath(QString("%1/shares/%2").arg(_version.left(1), file));
+
+    QString signature = oAuthSign(url);
+    url.addQueryItem("oauth_signature", QUrl::toPercentEncoding(signature));
+
+    int reqnr = sendRequest(url);
+    if(blocking)
+    {
+        requestMap[reqnr].type = QDROPBOX_REQ_BSHRDLN;
+        startEventLoop();
+    }
+    else
+        requestMap[reqnr].type = QDROPBOX_REQ_SHRDLNK;
+
+    return;
+}
+
+QUrl QDropbox::requestSharedLinkAndWait(QString file)
+{
+    requestSharedLink(file,true);
+    QDropboxJson json(_tempJson.strContent());
+    QString urlString = json.getString("url");
+    return QUrl(urlString);
+}
+
+void QDropbox::startEventLoop()
+{
+#ifdef QTDROPBOX_DEBUG
+    qDebug() << "QDropbox::startEventLoop()" << endl;
+#endif
+    if(_evLoop == NULL)
+        _evLoop = new QEventLoop(this);
+    _evLoop->exec();
+    return;
+}
+
 void QDropbox::startEventLoop()
 {
 #ifdef QTDROPBOX_DEBUG
@@ -923,6 +999,13 @@ void QDropbox::parseBlockingMetadata(QString response)
 	parseMetadata(response);
 	stopEventLoop();
 	return;
+}
+
+void QDropbox::parseBlockingSharedLink(QString response)
+{
+    clearError();
+    parseSharedLink(response);
+    stopEventLoop();
 }
 
 // check if the event loop has to be stopped after a blocking request was sent

--- a/src/qdropbox.h
+++ b/src/qdropbox.h
@@ -36,6 +36,8 @@ const qdropbox_request_type QDROPBOX_REQ_BACCTOK = 0x08;
 const qdropbox_request_type QDROPBOX_REQ_METADAT = 0x09;
 const qdropbox_request_type QDROPBOX_REQ_BACCINF = 0x0A;
 const qdropbox_request_type QDROPBOX_REQ_BMETADA = 0x0B;
+const qdropbox_request_type QDROPBOX_REQ_SHRDLNK = 0x0C;
+const qdropbox_request_type QDROPBOX_REQ_BSHRDLN = 0x0D;
 
 //! Internally used struct to handle network requests sent from QDropbox
 /*!
@@ -389,6 +391,21 @@ public:
 	 */
 	QDropboxFileInfo requestMetadataAndWait(QString file);
 
+	 /*!
+	 * \brief Creates and returns a Dropbox link to files or folders users can use to view a preview of the file in a web browser.
+	 * \param path from the file i.e. /dropbox/hello.txt
+	 * \param blocking
+	 */
+         void requestSharedLink(QString file, bool blocking = false);
+
+	/*!
+	* \brief Works exactly like QDropbox::requestSharedLink() but blocks until link
+	* was receivied from the Dropbox Server.
+	* \param path from the file i.e. /dropbox/hello.txt
+	* \return Url to the file
+	*/
+	QUrl requestSharedLinkAndWait(QString file);
+    
 	/*!
 	  Resets the last error. Use this when you reacted on an error to delete the error flag.
 	*/
@@ -461,6 +478,12 @@ signals:
 	  \param metadataJson JSON string that contains the metadata information
 	*/
 	void metadataReceived(QString metadataJson);
+	
+	/*!
+	Emmited when shared link was received. Only relevant for non-blocking use of sharedLink()
+	\param sharedLinkJson string than contains the share link information.
+	*/
+	void sharedLinkReceived(QString sharedLink);
 
 public slots:
 
@@ -514,10 +537,12 @@ private:
 	void responseBlockingAccessToken(QString response);
     void parseToken(QString response);
     void parseAccountInfo(QString response);
+    void parseSharedLink(QString response);
 	void checkReleaseEventLoop(int reqnr);
 	void parseMetadata(QString response);
 	void parseBlockingAccountInfo(QString response);
 	void parseBlockingMetadata(QString response);
+	void parseBlockingSharedLink(QString response);
 	
 };
 


### PR DESCRIPTION
Im trying to add support for Sharedlinks. so i added two new methods:

QDropbox::requestSharedLink
QDropbox::requestSharedLinkAndWait

this methods are bases on the original request methods
But when i call one of this im get SIGSEV on QDropboxJson::~QDropboxJson What am i doing wrong?
