### PR TITLE
Support for OS X Framework

### DIFF
--- a/QtDropbox-Info.plist
+++ b/QtDropbox-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>de_DE</string>
+    <key>CFBundleIdentifier</key>
+    <string>lycis.github.io.QtDropbox</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>QtDropbox</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundleGetInfoString</key>
+    <string>Created by Alexander Saal</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleExecutable</key>
+    <string>QtDropbox</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>QtDropbox - by Daniel Eder and/or its subsidiary(-ies)
+
+Copyright © 2013 Daniel Eder. All rights reserved.</string>
+  </dict>
+</plist>

--- a/qtdropbox.config.pri
+++ b/qtdropbox.config.pri
@@ -1,0 +1,54 @@
+macx {
+  CONFIG += lib_bundle
+
+  CONFIG(release, debug|release) {
+    QMAKE_CFLAGS_RELEASE = $$QMAKE_CFLAGS_RELEASE_WITH_DEBUGINFO
+    QMAKE_CXXFLAGS_RELEASE = $$QMAKE_CXXFLAGS_RELEASE_WITH_DEBUGINFO
+    QMAKE_OBJECTIVE_CFLAGS_RELEASE =  $$QMAKE_OBJECTIVE_CFLAGS_RELEASE_WITH_DEBUGINFO
+    QMAKE_LFLAGS_RELEASE = $$QMAKE_LFLAGS_RELEASE_WITH_DEBUGINFO
+  }
+
+  QMAKE_LFLAGS_SONAME  = -Wl,-install_name,@executable_path/../Frameworks/
+  QMAKE_INFO_PLIST = QtDropbox-Info.plist
+  OTHER_FILES += QtDropbox-Info.plist
+
+  HEADER_FILES = src/qtdropbox_global.h \
+                 src/qdropbox.h \
+                 src/qtdropbox.h \
+                 src/qdropboxjson.h \
+                 src/qdropboxaccount.h \
+                 src/qdropboxfile.h \
+                 src/qdropboxfileinfo.h
+
+  QMAKE_FRAMEWORK_VERSION = A
+  QTDROPBOX_FRAMEWORK_HEADERS.version = Versions
+  QTDROPBOX_FRAMEWORK_HEADERS.path  = Headers
+  QTDROPBOX_FRAMEWORK_HEADERS.files = $${HEADER_FILES}
+
+  QMAKE_BUNDLE_DATA += QTDROPBOX_FRAMEWORK_HEADERS
+}
+else {
+
+  OTHER_FILES += \
+      libqtdropbox.pri
+
+  target.path = lib/
+
+  #-------------------------------------------------
+  # Documentation target
+  #-------------------------------------------------
+  documentation.commands = doxygen doc/doxygen.conf
+  QMAKE_EXTRA_TARGETS += documentation
+
+  #-------------------------------------------------
+  # Package target
+  #-------------------------------------------------
+  package.files = libqtdropbox.pri \
+                  src/*.h
+  package.path = qtdropbox
+
+  #-------------------------------------------------
+  # install definitions
+  #-------------------------------------------------
+  INSTALLS += target package
+}

--- a/qtdropbox.pro
+++ b/qtdropbox.pro
@@ -29,25 +29,4 @@ HEADERS += \
 
 TARGET = QtDropbox
 
-OTHER_FILES += \
-    libqtdropbox.pri
-
-target.path = lib/
-
-#-------------------------------------------------
-# Documentation target
-#-------------------------------------------------
-documentation.commands = doxygen doc/doxygen.conf
-QMAKE_EXTRA_TARGETS += documentation
-
-#-------------------------------------------------
-# Package target
-#-------------------------------------------------
-package.files = libqtdropbox.pri \
-                src/*.h
-package.path = qtdropbox
-
-#-------------------------------------------------
-# install definitions
-#-------------------------------------------------
-INSTALLS += target package
+include(qtdropbox.config.pri)


### PR DESCRIPTION
The usage of this OS X Framework can be used in your own project like this

macx {
INCLUDEPATH += $${QTDROPBOXDIR}/QtDropbox.framework/Versions/A/Headers
DEPENDPATH += $${QTDROPBOXDIR}/QtDropbox.framework/Versions/A/Headers

QMAKE_PRE_LINK = rm -rf $${DESTDIR}/$${TARGET}.app/Contents/Frameworks && \
                                  mkdir -p $${DESTDIR}/$${TARGET}.app/Contents/Frameworks && \
                                  cp -R $${QTDROPBOXDIR}/QtDropbox.framework \
                                  $${DESTDIR}/$${TARGET}.app/Contents/Frameworks/QtDropbox.framework

LIBS += -F$${DESTDIR}/$${TARGET}.app/Contents/Frameworks
LIBS += -framework QtDropbox
}
