### PR TITLE
Update to fix issue #50

### DIFF
--- a/src/qdropboxdeltaresponse.h
+++ b/src/qdropboxdeltaresponse.h
@@ -22,7 +22,7 @@ typedef QMap<QString, QSharedPointer<QDropboxFileInfo> > QDropboxDeltaEntryMap;
 /*!
   This structure is used to carry the (multi-part) response from a call to the delta API.
  */
-class QDropboxDeltaResponse
+class QTDROPBOXSHARED_EXPORT QDropboxDeltaResponse
 {
 public:
     //! Constructs a blank QDropboxDeltaResponse object.


### PR DESCRIPTION
#50 The issue that was that QTDROPBOXSHARED_EXPORT wasn't being put in front of the class definition, which caused the generated libraries not to include this class and its functions.
